### PR TITLE
Some of the json files have floats not ints and structse need ints

### DIFF
--- a/scripts/convert-animation.py
+++ b/scripts/convert-animation.py
@@ -43,6 +43,6 @@ for filename in sys.argv[1:]:
 			for x in range(len(row)):
 				column = row[x]
 				for color in range(min(len(column), 3)):
-					f.write(struct.pack('B', 255*column[color]))
+					f.write(struct.pack('B', int(255*column[color])))
 	f.close()
 	print('Created {} from {}'.format(out_filename, filename))


### PR DESCRIPTION
To address this error. Cause the images contain floats.
Traceback (most recent call last):
  File "..\scripts\convert-animation.py", line 48, in <module>
    f.write(struct.pack('B', 255*column[color]))
struct.error: required argument is not an integer